### PR TITLE
Fixed Bugs in deleteResp function -- Now deletes correct response

### DIFF
--- a/Class.cpp
+++ b/Class.cpp
@@ -22,15 +22,12 @@ Prog::~Prog(){
 /*
 Function prototype:
 int Prog::hashSum(string x)
-
 Function description:
 This method calculates the hashcode which is based on the predetermined tablesize in Class.h
-
 Example:
 Prog ht;
 ht.hashSum("hello");
-
-Precondition: Takes the ascii values of the string x and adds them up. Then using the modulo operator, 
+Precondition: Takes the ascii values of the string x and adds them up. Then using the modulo operator,
 finds the hash index with the predetermined tablesize
 Post condition: returns the hash index to be used elsewhere
 */
@@ -45,21 +42,18 @@ int Prog::hashSum(string x){
 /*
 Function prototype:
 void Prog::insertResp(string in_keyword, string in_response)
-
 Function description:
 Inserts a keyword and response into the hashtable
-
 Example:
 Prog ht;
 ht.insertResp("hello", "how are you?")
-
 Precondition: Unused Indexes and linked lists are stored as NULL. Hash code is calculated from the hashSum function and then
 inserted. The input names are the keywords and the responses
 Post condition: successfully inserts a keyword with matching response. If there is more than one keyword with the same value
 it is added to a linked list. If the keyword has multiple occurances, only the response is added to the specific keyword
 */
 void Prog::insertResp(string in_keyword, string in_response){
-	int index = hashSum(in_keyword); 
+	int index = hashSum(in_keyword);
 	if (hashTable[index] == NULL){
 		hashTable[index] = new vector<LizaKey>;
 		hashTable[index]->push_back(LizaKey(in_keyword,in_response));
@@ -78,14 +72,11 @@ void Prog::insertResp(string in_keyword, string in_response){
 /*
 Function prototype:
 void Prog::displayResp(string in_keyword){
-
 Function description:
 This method finds a randomly generated index of a keyword
-
 Example:
 Prog ht;
 ht.displayResp("hello")
-
 Precondition: srand is calculated using the time to which it loads up numbers to be used. For example,
 it would load up 67 and use that for rand(). findKey is used to search the hashtable for the keyword that was entered
 Post condition: calculates a random index and prints out the response at that index
@@ -100,14 +91,11 @@ void Prog::displayResp(string in_keyword){
 /*
 Function prototype:
 LizaKey * Prog::findKey(string in_keyword)
-
 Function description:
 finds the keyword that was entered
-
 Example:
 Prog ht;
 ht.findKey("hello")
-
 Precondition: in_keyword is the keywored entered by the user. All unused indexs are set to NULL
 Post condition: Finds and stores the keyword in the hashtable and returns this value.
 */
@@ -116,7 +104,7 @@ LizaKey * Prog::findKey(string in_keyword){
 	bool found = false;
 	LizaKey *foundResp = NULL;
 
-	if (hashTable[index] != NULL){ 
+	if (hashTable[index] != NULL){
 		for (int i = 0; i < hashTable[index]->size(); i++){
 			if ((*hashTable[index])[i].keyword == in_keyword){
 				foundResp = &(*hashTable[index])[i];
@@ -133,16 +121,13 @@ LizaKey * Prog::findKey(string in_keyword){
 /*
 Function prototype:
 void Prog::deleteKey(string in_keyword)
-
 Function description:
-This method calculates the hashcode for the input keyword name, and deletes the keyword from the hash table. 
+This method calculates the hashcode for the input keyword name, and deletes the keyword from the hash table.
 Handles cases where movie is first, mid, or last node in the chain.
-
 Example:
 HashTable ht;
 ht.deleteKey("hello")
-
-Precondition: Unused locations in hashTable vector are NULL. Keywords stored using correctly calculated hash 
+Precondition: Unused locations in hashTable vector are NULL. Keywords stored using correctly calculated hash
 code calculated from the input Keyword. The input string name is the keyword
 Post condition: Keyword node deleted from chain and memory freed. Pointers updated to bypass deleted keyword.
 */
@@ -156,7 +141,7 @@ void Prog::deleteKey(string in_keyword){
 				found = true;
 				break;
 			}
-		} 
+		}
 		if (hashTable[index]->size() == 0){
 			delete hashTable[index];
 			hashTable[index] = NULL;
@@ -170,20 +155,18 @@ void Prog::deleteKey(string in_keyword){
 /*
 Function prototype:
 void Prog::deleteResp(string in_keyword, int index)
-
 Function description:
 This method deletes the response at a certain index
-
 Example:
 Prog ht;
 ht.deleteResp("hello", 0)
-
 Precondition: Finds the keyword. If the keyword is not found, it should be produced as NULL. If the index is out of range of the
 size of the responses, then the code stops
 Post condition: successfully deletes the index from memory.
 */
 void Prog::deleteResp(string in_keyword, int index){
 	LizaKey *found = findKey(in_keyword);
+
 	if (found == NULL){
 		cout << "Keyword not found" << endl;
 	}
@@ -191,22 +174,19 @@ void Prog::deleteResp(string in_keyword, int index){
 		cout << "Index not found" << endl;
 	}
 	else{
-		found->response.erase(found->response.begin()+index-1);
+		found->response.erase(found->response.begin()+index);   //Used to be index-1
 		cout << "Deleted response at index " << index << endl;
 	}
 }
 /*
 Function prototype:
 void Prog::searchStr(string sentence)
-
 Function description:
 Simliar to findKey, this function searches the hashtable for a matching keyowrd with the inputted sentence.
-
 Example:
 Prog ht;
 ht.searchStr("Hi, how are you today?")
-
-Precondition: string sentence is the input the user enters. 
+Precondition: string sentence is the input the user enters.
 Post condition: Keyword found that matches a word in the sentence, outputs the random response using displayResp()
 */
 void Prog::searchStr(string sentence){
@@ -231,14 +211,11 @@ void Prog::searchStr(string sentence){
 /*
 Function prototype:
 string Prog::Replace(string str, string oldStr, string newStr)
-
 Function description:
 This method replaces a word with another word in a string
-
 Example:
 Prog ht;
 ht.Replace("hello hello goodbye world", "goodbye", "hello")
-
 Precondition: str, oldStr, and newStr are all used from the read in file and are all valid ascii strings. Creates a new string
 instead of replacing the old one
 Post condition: returns the new string
@@ -254,14 +231,11 @@ string Prog::Replace(string str, string oldStr, string newStr){
 /*
 Function prototype:
 void Prog::printResp(string in_keyword)
-
 Function description:
 This method prints just the responses at a certain keyword
-
 Example:
 Prog ht;
 ht.printResp("hello")
-
 Precondition: intput is a keyword
 Post condition: prints all the responses by using a for loop for the size of the vector
 */
@@ -279,20 +253,17 @@ void Prog::printResp(string in_keyword){
 /*
 Function prototype:
 void Prog::printKey()
-
 Function description:
 This method print out all the keys in the hashtable
-
 Example:
 Prog ht;
 ht.printKey()
-
 Precondition: No input, takes the hashtable and skips the NULL
-Post condition: prints out the entire keyowrd list. 
+Post condition: prints out the entire keyowrd list.
 */
 void Prog::printKey(){
 	cout << "Keywords:" << endl;
-	bool empty = true; 
+	bool empty = true;
 	for (int i = 0; i < tableSize; i++){
 		if (hashTable[i] != NULL){
 			for (int j = 0; j < hashTable[i]->size(); j++){
@@ -308,19 +279,16 @@ void Prog::printKey(){
 /*
 Function prototype:
 void Prog::printAllResps()
-
 Function description:
 This method is a combination of printKey and printResp
-
 Example:
 Prog ht;
 ht.printAllResps()
-
 Precondition: Uses the hashtable and traverses through it.
 Post condition: Prints the keyword and assciated responses
 */
 void Prog::printAllResps(){
-	bool empty = true; 
+	bool empty = true;
 	for (int i = 0; i < tableSize; i++){
 		if (hashTable[i] != NULL){
 			for (int j = 0; j < hashTable[i]->size(); j++){


### PR DESCRIPTION
I noticed in the Delete Response option, the item being deleted was one index off. For example, if I typed delete response 1, it would delete response at index 0. Or if I deleted response 0, the program would throw a segmentation fault. This is my code, and I believe it fixed the bug to delete the correct response index now.
